### PR TITLE
evett一覧表示の実装

### DIFF
--- a/app/assets/stylesheets/evett/index.scss
+++ b/app/assets/stylesheets/evett/index.scss
@@ -1,5 +1,6 @@
 a {
   text-decoration: none;
+  color: black;
 }
 
 .main {
@@ -8,20 +9,24 @@ a {
 /* 商品一覧 */
 
 .evett-contents {
-  height: 80vh;
   background-color: white;
   display: flex;
+  justify-content: center;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-end;
   padding: 10vh 0;
-  overflow: scroll;
 }
 
 .evett_content {
+  display: flex;
+  width: 70%;
+  margin-top: 20px;
+}
+
+.evett_area {
   background-color: #9ddd88;
   width: 600px;
   height: 100px;
-  margin-top: 20px;
   padding: 15px;
   display: flex;
   justify-content: space-between;
@@ -36,18 +41,36 @@ a {
 .right_content {
   line-height: 40px;
   font-size: 24px;
-  width: 40%;
+  width: 25%;
+  display: flex;
+  align-items: center;
 }
 
-.evett_menu {
+.evett_menus {
   text-align: end;
+  width: 100%;
 }
 
 .evett_payment_btn {
   background-color: red;
   color: #FFF;
-  margin-right: 50px;
   text-align: center;
+}
+
+.evett_menu {
+  width: 60px;
+  text-align: center;
+  font-size: 24px;
+  display: block;
+}
+
+.evett_menu li {
+  display: none;
+}
+
+.evett_menu:hover li {
+  display: block;
+  cursor: pointer;
 }
 
 .evett-lists {
@@ -89,6 +112,7 @@ a {
   right: 32px;
   position: fixed;
   padding: 15px;
+  z-index: 1;
 }
 
 .purchase-btn-text {

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -4,6 +4,8 @@
   color: #FFF;
   background-color: #272727;
   text-align: center;
+  position: absolute;
+  bottom: 0;
 }
 
 .footer-contents {

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -37,6 +37,7 @@
 
 .list-name {
   text-decoration: none;
+  padding: 3px;
   margin-right: 3vw;
   color: #333333;
 }

--- a/app/controllers/evetts_controller.rb
+++ b/app/controllers/evetts_controller.rb
@@ -1,9 +1,15 @@
 class EvettsController < ApplicationController
   before_action :authenticate_user!, only: :new
+  before_action :index_evett_all, only: [:index, :index_freind, :index_user]
   #  before_action :unless_user_id, only: [:edit, :destroy]
 
   def index
-    @evetts = Evett.all.order('created_at DESC')
+  end
+
+  def index_freind
+  end
+
+  def index_user
   end
 
   def new
@@ -27,5 +33,9 @@ class EvettsController < ApplicationController
 
   def unless_user_id
     redirect_to root_path unless current_user.id == @evett.user_id
+  end
+
+  def index_evett_all
+    @evetts = Evett.all.order('created_at DESC')
   end
 end

--- a/app/javascript/evett_menu.js
+++ b/app/javascript/evett_menu.js
@@ -1,0 +1,10 @@
+const evettMenu = () => {
+  const menuBtn = document.getElementById("menu_btn")
+  const menu = document.getElementById("menu")
+
+  menuBtn.addEventListener('mouseover', () => {
+    menu.setAttribute("style", "display: block;")
+  });
+};
+
+window.addEventListener('load', evettMenu);

--- a/app/javascript/header.js
+++ b/app/javascript/header.js
@@ -1,0 +1,17 @@
+const header = () => {
+  const allUser = document.getElementById('all_user_tag')
+  const friend = document.getElementById('friend_tag')
+  const onlyUser = document.getElementById('only_user_tag')
+  allUser.addEventListener('mouseover', () => {
+    allUser.setAttribute("style", "background-color: lightblue;")
+  });
+  allUser.addEventListener('click', (e) => {
+    e.preventDefault();
+    const XHR = new XMLHttpRequest();
+    XHR.open("GET", "/evetts", true);
+    XHR.responseType = "json";
+    XHR.send();
+  });
+};
+
+window.addEventListener('load', header);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,10 +4,11 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+//require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
+//require("../evett_menu")
+//require("../header")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/evetts/index_freind.html.erb
+++ b/app/views/evetts/index_freind.html.erb
@@ -4,7 +4,7 @@
   <%# evett一覧 %>
   <div class='evett-contents' >
     <% @evetts.each do |evett| %>
-      <% if evett.share_area_id == 1 %>
+      <% if evett.share_area_id == 2 %>
         <div class='evett_content'>
           <div class='evett_area' >
             <div class='left_content'>
@@ -33,7 +33,7 @@
               </li>
             </ul>
         </div>
-      <% end %>
+        <% end %>
     <% end %>
   </div>
   <%# /evett一覧 %>

--- a/app/views/evetts/index_user.html.erb
+++ b/app/views/evetts/index_user.html.erb
@@ -4,7 +4,7 @@
   <%# evett一覧 %>
   <div class='evett-contents' >
     <% @evetts.each do |evett| %>
-      <% if evett.share_area_id == 1 %>
+      <% if evett.share_area_id == 3 && evett.user.id == current_user.id %>
         <div class='evett_content'>
           <div class='evett_area' >
             <div class='left_content'>
@@ -33,7 +33,7 @@
               </li>
             </ul>
         </div>
-      <% end %>
+        <% end %>
     <% end %>
   </div>
   <%# /evett一覧 %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,9 +5,11 @@
   </div>
   <div class='nav'>
     <ul class='lists-left'>
-      <li><%= link_to '誰でも', "#", class: "list-name" %></li>
-      <li><%= link_to '友達', "#", class: "list-name" %></li>
-      <li><%= link_to 'ユーザー名', "#", class: "list-name" %></li>
+      <li><%= link_to'誰でも', root_path, class: "list-name", id:"all_user_tag" %></li>
+      <% if user_signed_in? %>
+        <li><%= link_to '友達', evetts_index_freind_path, class: "list-name", id:"friend_tag" %></li>
+        <li><%= link_to current_user.nickname, evetts_index_user_path, class: "list-name", id:"only_user_tag" %></li>
+      <% end %>
     </ul>
     <ul class='lists-right'>
       <% if user_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "evetts#index"
   resources :evetts, only: [:index, :new, :create]
+  get "evetts/index_freind"
+  get "evetts/index_user"
 end


### PR DESCRIPTION
# What
投稿されたevettを一覧表示する機能を実装
# Why
それぞれの投稿に設定された公開範囲に応じて、evettを一覧表示するため

[こちらの商品を使用しました](https://gyazo.com/15cbfa2146c5f42c6e7f9a72d9bccf72)
[evettが一覧で表示されている画像（2つ以上のevettが出品されている状態を撮影してください。表示順を確かめるためです）
](https://gyazo.com/a07fb021a2e097b5ee1c15d24f8e6b91)
[ ログインしていると、「友達、ユーザーのニックネーム」のメニュータブがヘッダーに表示されており、クリックすると投稿が切り替わる動画](https://gyazo.com/046d4f595f3d5cc00db8e5795a50cc85)
[ ログアウト状態では、ヘッダーには「誰でも」のメニュータブしか表示されていない動画](https://gyazo.com/abc414d68783df0e0a19ad47660e0784)