### PR TITLE
evett情報編集機能の実装

### DIFF
--- a/app/assets/stylesheets/evett/new.css
+++ b/app/assets/stylesheets/evett/new.css
@@ -97,10 +97,11 @@
   display: flex;
   justify-content: space-between;
   padding: 2vh 0;
+  width: 70%;
 }
 
 .evetts-detail>.form {
-  width: 300px;
+  width: 450px;
   padding: 2vh 0;
 }
 
@@ -114,11 +115,6 @@
   flex-direction: column;
   margin: 0 auto;
   padding-top: 20px;
-}
-
-.form-text-wrap {
-  width: 100%;
-  height: 20%;
 }
 
 .form-text {

--- a/app/controllers/evetts_controller.rb
+++ b/app/controllers/evetts_controller.rb
@@ -1,6 +1,7 @@
 class EvettsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :new]
-  #  before_action :unless_user_id, only: [:edit, :destroy]
+  before_action :authenticate_user!, only: [:index, :new, :edit, :show]
+  before_action :evett_find, only: [:show, :edit, :update]
+  before_action :unless_user_id, only: [:edit, :destroy]
 
   def index
     @evetts_all = Evett.where(share_area_id: 1).order('created_at DESC')
@@ -22,7 +23,17 @@ class EvettsController < ApplicationController
   end
 
   def show
-    @evett = Evett.find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+    if @evett.update(evett_params)
+      redirect_to evett_path(@evett.id)
+    else
+      render :edit
+    end
   end
 
   private
@@ -32,6 +43,10 @@ class EvettsController < ApplicationController
   end
 
   def unless_user_id
-    redirect_to root_path unless current_user.id == @evett.user_id
+    redirect_to root_path unless @evett.user_id == current_user.id
+  end
+
+  def evett_find
+    @evett = Evett.find(params[:id])
   end
 end

--- a/app/views/evetts/_evett.html.erb
+++ b/app/views/evetts/_evett.html.erb
@@ -24,7 +24,7 @@
     <% if evett.user_id == current_user.id %>
       <ul class="evett_menu">
         <li>
-          <%= link_to "編集", root_path %>
+          <%= link_to "編集", edit_evett_path(evett.id), method: :get %>
         </li>
         <li>
           <%= link_to "削除", root_path %>

--- a/app/views/evetts/edit.html.erb
+++ b/app/views/evetts/edit.html.erb
@@ -1,0 +1,93 @@
+<div class="evetts-sell-contents">
+  <header class="evetts-sell-header">
+    <%= link_to "evett", root_path %>
+  </header>
+  <div class="evetts-sell-main">
+    <h2 class="evetts-sell-title">evettの情報を入力</h2>
+    <%= form_with model: @evett, local: true do |f| %>
+
+    <%= render 'shared/error_messages', model: f.object %>
+
+    <%# evett名とevett説明 %>
+    <div class="new-evetts">
+      <div class="weight-bold-text">
+        evett名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :name, class:"evetts-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="evetts-explain">
+        <div class="weight-bold-text">
+          evettの説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :text, class:"evetts-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）例）NIKEの最新スニーカーを買う" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /evett名とevett説明 %>
+
+    <%# evett詳細について %>
+    <div class="evetts-detail">
+      <div class="form">
+        <div class="weight-bold-text">
+          公開範囲の設定
+        </div>
+        <%= f.collection_select(:share_area_id, ShareArea.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="form-area">
+          <div class='form-text-wrap'>
+            <label class="form-text">目標日</label>
+            <%= f.date_field(:limit_date, value: Time.now.strftime("2022Y-1m-1d")) %>
+            <% unless @evett.limit_date.blank? %>
+              <p>＊<%= @evett.limit_date %>が現在入力されています。入力してください。</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <%# /evett詳細について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>設定価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "投稿する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">evett利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <p class="inc">
+      ©︎Evett,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/evetts/show.html.erb
+++ b/app/views/evetts/show.html.erb
@@ -30,7 +30,7 @@
     <% if @evett.user_id == current_user.id %>
     <ul class="menu_tag">
       <li>
-        <%= link_to "編集", "#" %>
+        <%= link_to "編集", edit_evett_path(@evett.id), method: :get  %>
       </li>
       <li>
         <%= link_to "削除", "#" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "evetts#index"
-  resources :evetts, only: [:index, :new, :create, :show]
+  resources :evetts, only: [:index, :new, :create, :show, :edit, :update]
   get "evetts/index"
 end


### PR DESCRIPTION
# What
evett投稿の編集機能の実装
# Why
投稿済みのevettの情報を編集するため

[ログイン状態のevett投稿者は、evett情報編集ページに遷移できる動画](https://gyazo.com/45fe64d0277acde482a5d87092a4207e)
 [必要な情報を適切に入力して「変更する」ボタンを押すと、evettの情報を編集できる動画](https://gyazo.com/a08bdbc10f4063a5440a3ad397454f90)
 [入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画](https://gyazo.com/a3710f9edda69a75ca61a698e7a41711)
[ ログイン状態の場合でも、URLを直接入力して自身が投稿していないevettのevett情報編集ページへ遷移しようとすると、トップページに遷移する動画](https://gyazo.com/35d2033b629eae8112e98c5fe21c8426)
 [ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画](https://gyazo.com/814955fd2825159b2bd73fa5b88da9d1)
[ evett名や説明など、すでに登録されているevett情報はevett情報編集画面を開いた時点で表示される動画](https://gyazo.com/0b59caab17ce303c8048f584c2de8da8)