### PR TITLE
マイページ機能実装

### DIFF
--- a/app/assets/stylesheets/evett/show.css
+++ b/app/assets/stylesheets/evett/show.css
@@ -103,6 +103,24 @@
   margin-top: 15px;
 }
 
+.evett_show_name {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+}
+
+.evett_show_name h1 {
+  background-color: #3ccace;
+  padding: 0 20px;
+  border-radius: 20px;
+}
+
+.evett_show_name h1 a {
+  color: #090909;
+  font-weight: bold;
+  font-size: 28px;
+}
+
 .evett_text {
   width: 110%;
   height: 50%;

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -4,7 +4,7 @@
 
 .header {
   width: 100vw;
-  height: 13vh;
+  height: 100px;
   padding: 1.5vh 7vw 0 7vw;
   background-color: rgb(28, 244, 240);
   display: flex;

--- a/app/assets/stylesheets/user/show.css
+++ b/app/assets/stylesheets/user/show.css
@@ -10,6 +10,7 @@
   padding: 20px;
   color: white;
   width: 20vw;
+  max-width: 150px;
   border-radius: 40px 0 0 40px;
 }
 
@@ -18,7 +19,7 @@
 }
 
 .Card__title {
-  font-size: 24px;
+  font-size: 22px;
   margin-bottom: 20px;
   border-bottom: 1px solid white;
 }
@@ -36,6 +37,12 @@
 
 .evett-list {
   padding: 20px 40px;
+  min-width: 1090px;
+}
+
+.evett_show_content {
+  display: flex;
+  margin: 0 10px 30px 10px;
 }
 
 .user-evett {
@@ -43,7 +50,6 @@
   flex-wrap: wrap;
   border-bottom: 1px solid lightgray;
   margin-bottom: 20px;
-  justify-content: center;
 }
 
 .user-evett p {
@@ -59,7 +65,6 @@
 .user-pay-evett {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
 }
 
 .user-pay-evett p {
@@ -79,5 +84,5 @@
   color: white;
   width: 20vw;
   border-radius: 0 40px 40px 0;
-  font-size: 24px;
+  font-size: 22px;
 }

--- a/app/views/evetts/show.html.erb
+++ b/app/views/evetts/show.html.erb
@@ -14,8 +14,9 @@
         <% end %>
       </ul>
       <div class='show_main_content'>
-        <div class='evett_name'>
+        <div class='evett_show_name'>
           <h2><%= @evett.name %></h2>
+          <h1><%= link_to @evett.user.nickname, user_path(@evett.user.id), method: :get %> </h1>
         </div>
         <div class='evett_show_box'>
           <%= @evett.text %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,63 +25,70 @@
           </div>
         </div>
       </div>
+    <% else %>
+      <div class="Card_area">
+        <h2><%= @user.nickname %><br><br>のマイページ</h2>
+      </div>
     <% end %>
     <div class='evett-list'>
       <div class= 'user-evett'>
         <p>投稿済みevett一覧</p>
       <% @evetts.each do |evett|%>
-        <li class='evett_content'>
-          <div class='evett_area' >
-            <ul class='content_menu'>
-              <% if evett.user_id == current_user.id %>
-                <li>
-                  <%= link_to "編集", edit_evett_path(evett.id), method: :get %>
-                </li>
-                <li>
-                  <%= link_to "削除", evett_path(evett.id), method: :delete %>
-                </li>
-              <% end %>
-            </ul>
-            <%= link_to evett_path(evett.id) do %>
-              <div class='main_content'>
-                <div class='evett_name'>
-                  <h2><%= evett.name %></h2>
-                </div>
-                <div class='evett_limit_date'>
-                  <% if evett.limit_date.present? %>
-                    <h2>目標日：<%= evett.limit_date %></h2>
-                  <% end %>
-                </div>
-                <div class='evett_price_back'>
-                  <h2 class="evett_price"><%= Payment.where(evett_id: evett.id).sum(:pay) %>/<%= evett.price %>円</h2>
-                  <% if Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price >= 100 %>
-                    <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
-                  <% else %>
-                    <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%;"></div>
-                  <% end %>
-                </div>
-                <div class='payment_area'>
-                  <%= link_to evett_payments_path(evett.id) do %>
-                    <div class='evett_payment_btn'>入金</div>
-                  <% end %>
-                  <div class='payment_percentage'>
-                    <% unless Payment.where(evett_id: evett.id).sum(:pay) == 0 %>
-                      <h2><%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
-                    <% else %>
-                      <h2>0%</h2>
+        <% if evett.user.id != current_user.id && evett.share_area_id == 3 %>
+        <% else %>
+          <li class='evett_show_content'>
+            <div class='evett_area' >
+              <ul class='content_menu'>
+                <% if evett.user_id == current_user.id %>
+                  <li>
+                    <%= link_to "編集", edit_evett_path(evett.id), method: :get %>
+                  </li>
+                  <li>
+                    <%= link_to "削除", evett_path(evett.id), method: :delete %>
+                  </li>
+                <% end %>
+              </ul>
+              <%= link_to evett_path(evett.id) do %>
+                <div class='main_content'>
+                  <div class='evett_name'>
+                    <h2><%= evett.name %></h2>
+                  </div>
+                  <div class='evett_limit_date'>
+                    <% if evett.limit_date.present? %>
+                      <h2>目標日：<%= evett.limit_date %></h2>
                     <% end %>
                   </div>
+                  <div class='evett_price_back'>
+                    <h2 class="evett_price"><%= Payment.where(evett_id: evett.id).sum(:pay) %>/<%= evett.price %>円</h2>
+                    <% if Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price >= 100 %>
+                      <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
+                    <% else %>
+                      <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%;"></div>
+                    <% end %>
+                  </div>
+                  <div class='payment_area'>
+                    <%= link_to evett_payments_path(evett.id) do %>
+                      <div class='evett_payment_btn'>入金</div>
+                    <% end %>
+                    <div class='payment_percentage'>
+                      <% unless Payment.where(evett_id: evett.id).sum(:pay) == 0 %>
+                        <h2><%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
+                      <% else %>
+                        <h2>0%</h2>
+                      <% end %>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            <% end %>
-          </div>
-        </li>
+              <% end %>
+            </div>
+          </li>
+        <% end %>
       <% end %>
       </div>
       <div class='user-pay-evett'>
         <p>入金済みevett一覧</p>
       <% @payments.each do |pay| %>
-        <li class='evett_content'>
+        <li class='evett_show_content'>
             <div class='evett_area' >
               <ul class='content_menu'>
                 <% if pay.evett.user_id == current_user.id %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -88,53 +88,56 @@
       <div class='user-pay-evett'>
         <p>入金済みevett一覧</p>
       <% @payments.each do |pay| %>
-        <li class='evett_show_content'>
-            <div class='evett_area' >
-              <ul class='content_menu'>
-                <% if pay.evett.user_id == current_user.id %>
-                  <li>
-                    <%= link_to "編集", edit_evett_path(pay.evett.id), method: :get %>
-                  </li>
-                  <li>
-                    <%= link_to "削除", evett_path(pay.evett.id), method: :delete %>
-                  </li>
-                <% end %>
-              </ul>
-              <%= link_to evett_path(pay.evett.id) do %>
-                <div class='main_content'>
-                  <div class='evett_name'>
-                    <h2><%= pay.evett.name %></h2>
-                  </div>
-                  <div class='evett_limit_date'>
-                    <% if pay.evett.limit_date.present? %>
-                      <h2>目標日：<%= pay.evett.limit_date %></h2>
-                    <% end %>
-                  </div>
-                  <div class='evett_price_back'>
-                    <h2 class="evett_price"><%= Payment.where(evett_id: pay.evett.id).sum(:pay) %>/<%= pay.evett.price %>円</h2>
-                    <% if Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price >= 100 %>
-                      <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
-                    <% else %>
-                      <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price %>%;"></div>
-                    <% end %>
-                  </div>
-                  <div class='payment_area'>
-                    <%= link_to evett_payments_path(pay.evett.id) do %>
-                      <div class='evett_payment_btn'>入金</div>
-                    <% end %>
-                    <div class='payment_percentage'>
-                      <% unless Payment.where(evett_id: pay.evett.id).sum(:pay) == 0 %>
-                        <h2><%=  Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price %>%</h2>
-                      <% else %>
-                        <h2>0%</h2>
+        <% if evett.user.id != current_user.id && evett.share_area_id == 3 %>
+        <% else %>
+          <li class='evett_show_content'>
+              <div class='evett_area' >
+                <ul class='content_menu'>
+                  <% if pay.evett.user_id == current_user.id %>
+                    <li>
+                      <%= link_to "編集", edit_evett_path(pay.evett.id), method: :get %>
+                    </li>
+                    <li>
+                      <%= link_to "削除", evett_path(pay.evett.id), method: :delete %>
+                    </li>
+                  <% end %>
+                </ul>
+                <%= link_to evett_path(pay.evett.id) do %>
+                  <div class='main_content'>
+                    <div class='evett_name'>
+                      <h2><%= pay.evett.name %></h2>
+                    </div>
+                    <div class='evett_limit_date'>
+                      <% if pay.evett.limit_date.present? %>
+                        <h2>目標日：<%= pay.evett.limit_date %></h2>
                       <% end %>
                     </div>
+                    <div class='evett_price_back'>
+                      <h2 class="evett_price"><%= Payment.where(evett_id: pay.evett.id).sum(:pay) %>/<%= pay.evett.price %>円</h2>
+                      <% if Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price >= 100 %>
+                        <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
+                      <% else %>
+                        <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price %>%;"></div>
+                      <% end %>
+                    </div>
+                    <div class='payment_area'>
+                      <%= link_to evett_payments_path(pay.evett.id) do %>
+                        <div class='evett_payment_btn'>入金</div>
+                      <% end %>
+                      <div class='payment_percentage'>
+                        <% unless Payment.where(evett_id: pay.evett.id).sum(:pay) == 0 %>
+                          <h2><%=  Payment.where(evett_id: pay.evett.id).sum(:pay) * 100 / pay.evett.price %>%</h2>
+                        <% else %>
+                          <h2>0%</h2>
+                        <% end %>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              <% end %>
-            </div>
-          </li>
-      <% end %>
+                <% end %>
+              </div>
+            </li>
+          <% end %>
+        <% end %>
       </div>
     </div>
     <% if current_user.id == @user.id%>


### PR DESCRIPTION
# What
マイページを実装してそのユーザーの投稿したevettと入金したevettを一覧表示する機能
# Why
ヘッダーのユーザー名やevett詳細ページのユーザー名をクリックするとそのユーザーのマイページに遷移できるようにするため

[トップページのユーザー名をクリックすると自分のマイページが表示されている動画](https://gyazo.com/9b51765c527ffefd959bbd84d0ee9602)
[ evett情報詳細ページのユーザー名をクリックするとそのevettを投稿したユーザーのマイページが表示されている動画](https://gyazo.com/98a4a4b9b4933b1abb1d24436926a529)
[ 自分のマイページに友達一覧、カード情報、投稿したevett一覧、入金したevett一覧が表示されている動画](https://gyazo.com/b6a112dd56e3a4ba8caf67a7c267048e)
[ 自分以外のユーザーのマイページにそのユーザーが、投稿したevett一覧、入金したevett一覧が表示されている動画](https://gyazo.com/44839dc6b680827bd98ae355778c7eca)

 マイページの投稿したevett一覧と入金したevett一覧の「自分のみ」で投稿したevettが本人以外に表示されないようになっている動画
 ユーザー１のマイページをユーザー１とユーザー４で比較して、ユーザー1のevett14の表示の有無を比較しています
[ユーザーのデータベースの写真](https://gyazo.com/62aebf46ea2a6f9fa33f8ddce7fc28e0)
[evettのデータベースの写真](https://gyazo.com/0fe5ac441c52d1170204c8815835a1c6)
[ユーザー１の場合](https://gyazo.com/012001fde1097319fd82904292e6d259)
[ユーザー４の場合](https://gyazo.com/d4588981989d8b4297fba418ce6af0ad)