### PR TITLE
フォロー一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/evett/show.css
+++ b/app/assets/stylesheets/evett/show.css
@@ -110,7 +110,7 @@
 }
 
 .evett_show_name h1 {
-  background-color: #3ccace;
+  background-color: white;
   padding: 0 20px;
   border-radius: 20px;
 }
@@ -118,7 +118,11 @@
 .evett_show_name h1 a {
   color: #090909;
   font-weight: bold;
-  font-size: 28px;
+  font-size: 22px;
+}
+
+.evett_show_name h1 a:hover {
+  color: red;
 }
 
 .evett_text {

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -61,6 +61,15 @@
   font-weight: bold;
 }
 
+.follow_btn {
+  padding: 6px;
+  border-radius: 20px;
+  background-color: white;
+}
+
+.follow_btn:hover {
+  color: red;
+}
 
 .logout {
   text-decoration: none;

--- a/app/assets/stylesheets/user/show.css
+++ b/app/assets/stylesheets/user/show.css
@@ -1,27 +1,8 @@
-.follow_btn:hover {
-  color: red;
-}
-
 .user-evett-area {
   padding: 20px;
   min-height: 70vh;
   width: 100%;
   display: flex;
-  justify-content: center;
-}
-
-.user_name_area {
-  background: linear-gradient(red, orange, yellow);
-  padding: 20px;
-  font-size: 24px;
-  color: white;
-  width: 240px;
-  height: 200px;
-  border-radius: 40px;
-}
-
-.user_name_area h2 {
-  margin-bottom: 30px;
 }
 
 #user-evett-list {
@@ -76,8 +57,9 @@
   width: 70vw;
   height: 80vh;
   border-radius: 200px;
-  padding: 10px 50px;
+  padding: 20px 100px;
   margin-top: 20px;
+  margin-left: 14%;
   display: none;
   justify-content: space-between;
   align-items: center;
@@ -98,6 +80,7 @@
 
 .Card_info {
   line-height: 40px;
+  min-height: 300px;
 }
 
 .new-card-link {
@@ -113,29 +96,35 @@
   color: white;
   width: 300px;
   height: 60vh;
-  font-size: 30px;
 }
 
 .follow-title {
   border-bottom: 1px solid white;
+  font-size: 30px;
   margin-bottom: 20px;
-}
-
-.follower {
-  margin-bottom: 10px;
-  line-height: 40px;
-  font-size: 18px;
 }
 
 .follow {
-  padding-bottom: 20px;
-  margin-bottom: 20px;
+  display: flex;
+  justify-content: start;
+  margin-top: 20px;
   line-height: 40px;
   font-size: 18px;
-  border-bottom: 1px solid white;
+  border-top: 1px solid white;
+}
+.follow h5 {
+  margin-right: 20px;
 }
 
 .follow_name {
   margin-bottom: 10px;
   font-size: 20px;
+}
+
+.follow_name a {
+  color: white;
+}
+
+.follow-area {
+  min-height: 300px;
 }

--- a/app/controllers/evetts_controller.rb
+++ b/app/controllers/evetts_controller.rb
@@ -26,18 +26,12 @@ class EvettsController < ApplicationController
   end
 
   def edit
+    session[:previous_url] = request.referer
   end
 
   def update
     if @evett.update(evett_params)
-      path = Rails.application.routes.recognize_path(request.referer)
-      if path[:controller] == "users"
-        redirect_to user_path(@evett.user.id)
-      elsif path[:controller] == "evetts" && path[:action] == "show"
-        redirect_to evett_path(@evett.id)
-      else
-        redirect_to root_path
-      end
+      redirect_to session[:previous_url]
     else
       render :edit
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
       @card = customer.cards.first
       
       @following_users = @user.following_user
-      @followed_users = @user.followed_user
+      @followed_users = @user.followed_user.order('created_at DESC')
     end
 
     @evetts = Evett.where(user_id: @user.id).order('created_at DESC')

--- a/app/views/friends/_follow.html.erb
+++ b/app/views/friends/_follow.html.erb
@@ -1,16 +1,16 @@
 <div class="follow-list">
   <div class="follow-title">
-    フォロー 一覧
+    友達一覧
   </div>
-  <div class="follower">
-    <h5>フォロワー<%= user.followed.count %>人</h5>
+  <div class="follow-area">
+    <% @followed_users.each do |followed| %>
+      <div class="follow_name">
+        <%= link_to followed.nickname, user_path(followed.id), method: :get %>
+      </div>
+    <% end %>
   </div>
   <div class="follow">
     <h5>フォロー<%= user.following.count %>人</h5>
+    <h5>フォロワー<%= user.followed.count %>人</h5>
   </div>
-  <% @followed_users.each do |followed| %>
-    <div class="follow_name">
-      <%= followed.nickname %>
-    </div>
-  <% end %>
 </div>

--- a/app/views/shared/_mypage-header.html.erb
+++ b/app/views/shared/_mypage-header.html.erb
@@ -11,8 +11,13 @@
     </ul>
     <ul class='lists-right'>
       <% if user_signed_in? %>
-        <li><%= link_to current_user.nickname, user_path(current_user), class: "user-nickname" %></li>
-        <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li>
+        <% if current_user.id == @user.id %>
+          <li><%= link_to current_user.nickname, user_path(current_user), class: "user-nickname" %></li>
+          <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li>
+        <% else %>
+          <li class="user-nickname"><%= @user.nickname %></li>
+          <li><%= render 'friends/follow_btn', user_id: @user %></li>
+        <% end %>
       <% else %>
         <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>
         <li><%= link_to '新規登録', new_user_registration_path, class: "sign-up" %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,6 @@
 <%= render "shared/mypage-header"%>
 <div class="main">
   <div class='user-evett-area'>
-    <% if current_user.id == @user.id%>
-    <% else %>
-      <div class="user_name_area">
-        <h2><%= @user.nickname %><br>のマイページ</h2>
-        <h2><%= render 'friends/follow_btn', user_id: @user %></h2>
-      </div>
-    <% end %>
     <div class='evett-list', id="user-evett-list">
       <div class= 'user-evett'>
         <p>投稿済みevett一覧</p>
@@ -139,9 +132,9 @@
           /
           <%= @card[:exp_year] %><br>
           <%# 有効期限の「年」を取得 %>
-          <div class="new-card-link">
-            <%= link_to '新しいカード情報を登録する', new_user_card_path(current_user)%>
-          </div>
+        </div>
+        <div class="new-card-link">
+          <%= link_to '新しいカード情報を登録する', new_user_card_path(current_user)%>
         </div>
       </div>
       <%= render 'friends/follow', user: @user %>


### PR DESCRIPTION
# What
マイページにフォローしたユーザーを一覧表示させる機能
# Why
フォローしたユーザーを一覧表示をして、そのユーザーのマイページに遷移できるようにするため

[自分のマイページにはフォローしたユーザーが一覧表示されている動画](https://gyazo.com/d0b6e4490a9e728ea6a58ca389050e32)
 [フォローしたユーザー名をクリックするとそのユーザーのマイページに遷移する動画](https://gyazo.com/d5f6d4c774c97bf43b1081e4b169f1e2)
[ 自分以外のマイページにはフォローしたユーザーが一覧表示されていない動画](https://gyazo.com/5e3e489c6570dec59f590ba787ff0cd8)
 [上から新しく登録した順番に表示されている動画](https://gyazo.com/b2b093b5e96562df8745e6a3a37db569)