### PR TITLE
フォロー削除機能の実装とevett一覧表示機能の修正

### DIFF
--- a/app/assets/stylesheets/user/show.css
+++ b/app/assets/stylesheets/user/show.css
@@ -105,8 +105,6 @@
 }
 
 .follow {
-  display: flex;
-  justify-content: start;
   margin-top: 20px;
   line-height: 40px;
   font-size: 18px;
@@ -117,12 +115,23 @@
 }
 
 .follow_name {
+  padding: 5px;
   margin-bottom: 10px;
-  font-size: 20px;
+  border-radius: 10px;
+  font-size: 18px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .follow_name a {
   color: white;
+  padding: 6px;
+}
+
+.follow_name_btn:hover {
+  color: red;
+  background-color: white;
+  border-radius: 20px;
 }
 
 .follow-area {

--- a/app/controllers/evetts_controller.rb
+++ b/app/controllers/evetts_controller.rb
@@ -6,6 +6,9 @@ class EvettsController < ApplicationController
     @evetts_all = Evett.where(share_area_id: 1).order('created_at DESC')
     @evetts_friend = Evett.where(share_area_id: 2).order('created_at DESC')
     @evetts_only = Evett.where(share_area_id: 3).order('created_at DESC')
+    
+    @followed_users = current_user.followed_user
+    
   end
 
   def new

--- a/app/views/evetts/index.html.erb
+++ b/app/views/evetts/index.html.erb
@@ -40,7 +40,7 @@
                 <% end %>
                 <div class='payment_percentage'>
                   <% unless Payment.where(evett_id: evett.id).sum(:pay) == 0 %>
-                    <h2><%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
+                    <h2><%= Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
                   <% else %>
                     <h2>0%</h2>
                   <% end %>
@@ -54,52 +54,54 @@
   </div>
   <div class='not-active-evett' id="friend">
     <% @evetts_friend.each do |evett|%>
-      <li class='evett_content'>
-        <div class='evett_area' >
-          <ul class='content_menu'>
-            <% if evett.user_id == current_user.id %>
-              <li>
-                <%= link_to "編集", edit_evett_path(evett.id), method: :get %>
-              </li>
-              <li>
-                <%= link_to "削除", evett_path(evett.id), method: :delete %>
-              </li>
-            <% end %>
-          </ul>
-          <%= link_to evett_path(evett.id) do %>
-            <div class='main_content'>
-              <div class='evett_name'>
-                <h2><%= evett.name %></h2>
-              </div>
-              <div class='evett_limit_date'>
-                <% if evett.limit_date.present? %>
-                  <h2>目標日：<%= evett.limit_date %></h2>
-                <% end %>
-              </div>
-              <div class='evett_price_back'>
-                <h2 class="evett_price"><%= Payment.where(evett_id: evett.id).sum(:pay) %>/<%= evett.price %>円</h2>
-                <% if Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price >= 100 %>
-                  <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
-                <% else %>
-                  <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%;"></div>
-                <% end %>
-              </div>
-              <div class='payment_area'>
-                <%= link_to evett_payments_path(evett.id) do %>
-                  <div class='evett_payment_btn'>入金</div>
-                <% end %>
-                <div class='payment_percentage'>
-                  <% unless Payment.where(evett_id: evett.id).sum(:pay) == 0 %>
-                    <h2><%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
-                  <% else %>
-                    <h2>0%</h2>
+      <% if @followed_users.find_by(id: evett.user_id) != nil || evett.user.id == current_user.id %>
+        <li class='evett_content'>
+          <div class='evett_area' >
+            <ul class='content_menu'>
+              <% if evett.user_id == current_user.id %>
+                <li>
+                  <%= link_to "編集", edit_evett_path(evett.id), method: :get %>
+                </li>
+                <li>
+                  <%= link_to "削除", evett_path(evett.id), method: :delete %>
+                </li>
+              <% end %>
+            </ul>
+            <%= link_to evett_path(evett.id) do %>
+              <div class='main_content'>
+                <div class='evett_name'>
+                  <h2><%= evett.name %></h2>
+                </div>
+                <div class='evett_limit_date'>
+                  <% if evett.limit_date.present? %>
+                    <h2>目標日：<%= evett.limit_date %></h2>
                   <% end %>
                 </div>
+                <div class='evett_price_back'>
+                  <h2 class="evett_price"><%= Payment.where(evett_id: evett.id).sum(:pay) %>/<%= evett.price %>円</h2>
+                  <% if Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price >= 100 %>
+                    <div id="max_percentage", class='evett_price_bar' style="width: 100%;"></div>
+                  <% else %>
+                    <div class='evett_price_bar' style="width: <%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%;"></div>
+                  <% end %>
+                </div>
+                <div class='payment_area'>
+                  <%= link_to evett_payments_path(evett.id) do %>
+                    <div class='evett_payment_btn'>入金</div>
+                  <% end %>
+                  <div class='payment_percentage'>
+                    <% unless Payment.where(evett_id: evett.id).sum(:pay) == 0 %>
+                      <h2><%=  Payment.where(evett_id: evett.id).sum(:pay) * 100 / evett.price %>%</h2>
+                    <% else %>
+                      <h2>0%</h2>
+                    <% end %>
+                  </div>
+                </div>
               </div>
-            </div>
-          <% end %>
-        </div>
-      </li>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
     <% end %>
   </div>
   <div class='not-active-evett' id="user">

--- a/app/views/friends/_follow.html.erb
+++ b/app/views/friends/_follow.html.erb
@@ -6,11 +6,12 @@
     <% @followed_users.each do |followed| %>
       <div class="follow_name">
         <%= link_to followed.nickname, user_path(followed.id), method: :get %>
+        <%= link_to "解除", user_friend_path(followed.id), method: :delete, class: "follow_name_btn" %>
       </div>
     <% end %>
   </div>
   <div class="follow">
-    <h5>フォロー<%= user.following.count %>人</h5>
-    <h5>フォロワー<%= user.followed.count %>人</h5>
+    <h5>フォロー<%= user.following.count %>人（閲覧可能）</h5>
+    <h5>フォロワー<%= user.followed.count %>人（閲覧許可）</h5>
   </div>
 </div>

--- a/app/views/friends/_follow_btn.html.erb
+++ b/app/views/friends/_follow_btn.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.following?(user_id) %>
-  <%= link_to "フォロー外す", user_friend_path(user_id), method: :delete, class: "follow_btn" %>
+  <%= link_to "フォロー解除", user_friend_path(user_id), method: :delete, class: "follow_btn" %>
 <% else %>
   <%= link_to "フォローする", user_friend_path(user_id), method: :post, class: "follow_btn" %>
 <% end %>


### PR DESCRIPTION
# What
フォロー登録を削除する機能
# Why
フォローするユーザーを減らすことができるようにするため

[フォロー一覧表示のユーザー名の横の「解除」ボタンを押すとフォローを解除できる動画](https://gyazo.com/01e41ff5c3d74bf0c97c80ba6353e2ba)
[ フォローしているユーザーのマイページに「フォロー解除」ボタンがある動画](https://gyazo.com/6513ed7b3e6c9c0ecc14c8dbda0b1433)
[ フォロー削除したユーザーがマイページに一覧表示されていない動画](https://gyazo.com/f0cfb8da4c18d60734bd5c727a5a8145)
[ フォロー削除したユーザーのマイページに「フォローする」ボタンがある動画](https://gyazo.com/08141e8fe1fd81d2eb274fe6a9f90afa)