### PR TITLE
SNS連携機能の実装

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def facebook
+    authorization
+  end
+
+  def google_oauth2
+    authorization
+  end
+
+  private
+
+  def authorization
+    sns_info = User.from_omniauth(request.env['omniauth.auth'])
+    @user = sns_info[:user]
+
+    if @user.persisted? # ユーザー情報が登録済みなので、新規登録ではなくログイン処理を行う
+      sign_in_and_redirect @user, event: :authentication
+    else # ユーザー情報が未登録なので、新規登録画面へ遷移する
+      @sns_id = sns_info[:sns].id
+      render template: 'devise/registrations/new'
+    end
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  def create
+    if params[:sns_auth] == 'true'
+      pass = Devise.friendly_token
+      params[:user][:password] = pass
+      params[:user][:password_confirmation] = pass
+    end
+    super
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,8 +10,8 @@
 
     <%= render "shared/error_messages", model: f.object %>
     <div class="sns-links">
-      <%= link_to 'Facebookでログイン',root_path , class:"sns" %><%#, user_facebook_omniauth_authorize_path, class:"facebook", method: :post%>
-      <%= link_to 'Googleでログイン',root_path , class:"sns" %><%#, user_google_oauth2_omniauth_authorize_path, class:"google", method: :post%>
+      <%= link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, class:"facebook", method: :post%>
+      <%= link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, class:"google", method: :post%>
     </div>
 
     <div class="form-group">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,8 +13,8 @@
       </div>
       
       <div class="sns-links">
-        <%= link_to 'Facebookでログイン',root_path , class:"sns" %><%#, user_facebook_omniauth_authorize_path, class:"facebook", method: :post%>
-        <%= link_to 'Googleでログイン',root_path , class:"sns" %><%#, user_google_oauth2_omniauth_authorize_path, class:"google", method: :post%>
+        <%= link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, class:"facebook", method: :post%>
+        <%= link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, class:"google", method: :post%>
       </div>
 
       <div class="form-group">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,8 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.omniauth :facebook,ENV['FACEBOOK_CLIENT_ID'],ENV['FACEBOOK_CLIENT_SECRET']
+  config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   get 'cards/new'
   get 'users/show'
-  devise_for :users
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    registrations: 'users/registrations'
+  }
   root to: "evetts#index"
   resources :evetts do
     resources :payments, only: [:index, :create]

--- a/db/migrate/20220618030715_create_sns_credentials.rb
+++ b/db/migrate/20220618030715_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :provider
+      t.string :uid
+      t.references :user,  foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_13_073249) do
+ActiveRecord::Schema.define(version: 2022_06_18_030715) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "customer_token", null: false
@@ -52,6 +52,15 @@ ActiveRecord::Schema.define(version: 2022_06_13_073249) do
     t.index ["user_id"], name: "index_payments_on_user_id"
   end
 
+  create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -69,4 +78,5 @@ ActiveRecord::Schema.define(version: 2022_06_13_073249) do
   add_foreign_key "evetts", "users"
   add_foreign_key "payments", "evetts"
   add_foreign_key "payments", "users"
+  add_foreign_key "sns_credentials", "users"
 end

--- a/spec/factories/sns_credentials.rb
+++ b/spec/factories/sns_credentials.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :sns_credential do
+  end
+end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SnsCredential, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
SNSアカウントを用いたログインが可能な機能
# Why
新規登録時、ログイン時に一部の情報の入力を省略できるようにするため

[「新規登録」、「ログイン」画面にSNS連携用のリンクが表示されている動画](https://gyazo.com/7136df6dcf2544466a490d0df1c02026)
[ SNS連携をすると、ログイン画面のemail,passwordの入力が省略されている動画](https://gyazo.com/b88e43e0c4b7a1f37657850a92b5de0e)